### PR TITLE
serializer component needs both body and headers in envelop message

### DIFF
--- a/Messenger/KafkaTransport.php
+++ b/Messenger/KafkaTransport.php
@@ -74,9 +74,12 @@ class KafkaTransport implements TransportInterface
             case RD_KAFKA_RESP_ERR_NO_ERROR:
                 $this->logger->info(sprintf('Kafka: Message %s %s %s received ', $message->topic_name, $message->partition, $message->offset));
 
+                $decodedMessage = json_decode($message->payload, true);
+
                 /** @var Envelope $envelope */
                 $envelope = $this->serializer->decode(array(
-                    'body' => json_decode($message->payload, true)['body']
+                    'body' => $decodedMessage['body'],
+                    'headers' => $decodedMessage['headers']
                 ));
 
                 if ($envelope) {


### PR DESCRIPTION
When used with Symfony serializer component to have json in the topic instead of a php serialized object, you need both the body and headers to decode the message :

https://github.com/symfony/messenger/blob/master/Transport/Serialization/Serializer.php#L64