### PR TITLE
Bump bundle constraints to accept Symfony ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
     "php": "^7.1.3",
     "ext-json": "*",
     "ext-rdkafka": "^3.0.3",
-    "symfony/config": "^3.0||^4.0",
-    "symfony/dependency-injection": "^3.0||^4.0",
-    "symfony/http-kernel": "^3.0||^4.0",
-    "symfony/messenger": "^4.3"
+    "symfony/config": "^3.0||^4.0||^5.0",
+    "symfony/dependency-injection": "^3.0||^4.0|^5.0",
+    "symfony/http-kernel": "^3.0||^4.0||^5.0",
+    "symfony/messenger": "^4.3||^5.0"
   },
   "autoload": {
     "psr-4": { "Koco\\Kafka\\": "" }


### PR DESCRIPTION
This PR allows using the bundle in *Symfony* 5 projects.