### PR TITLE
Add flush timeout ms option to KafkaTransport configuration.

### DIFF
--- a/Messenger/KafkaTransport.php
+++ b/Messenger/KafkaTransport.php
@@ -40,12 +40,14 @@ class KafkaTransport implements TransportInterface
 
     /** @var bool */
     private $subscribed;
+    private $flushTimeout;
 
     public function __construct(
         LoggerInterface $logger,
         SerializerInterface $serializer,
         KafkaConf $kafkaConf,
         string $topicName,
+        int $flushTimeout,
         int $timeoutMs,
         bool $commitAsync
     ) {
@@ -56,6 +58,7 @@ class KafkaTransport implements TransportInterface
         $this->timeoutMs = $timeoutMs;
         $this->commitAsync = $commitAsync;
         $this->subscribed = false;
+        $this->flushTimeout = $flushTimeout;
     }
 
     public function get(): iterable
@@ -141,6 +144,8 @@ class KafkaTransport implements TransportInterface
         $payload = $this->serializer->encode($envelope);
 
         $topic->produce(RD_KAFKA_PARTITION_UA, 0, json_encode($payload));
+
+        $producer->flush($this->flushTimeout);
 
         return $envelope;
     }

--- a/Messenger/KafkaTransportFactory.php
+++ b/Messenger/KafkaTransportFactory.php
@@ -95,6 +95,7 @@ class KafkaTransportFactory implements TransportFactoryInterface
             $serializer,
             $conf,
             $options['topic']['name'],
+            $options['flushTimeout'] ?? 10000,
             $options['receiveTimeout'] ?? 10000,
             $options['commitAsync'] ?? false
         );

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ framework:
             producer:
                 dsn: '%env(KAFKA_URL)%'
                 options:
+                    flushTimeout: 10000
                     topic:
                         name: 'events'
                     kafka_conf:

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
   },
   "autoload": {
     "psr-4": { "Koco\\Kafka\\": "" }
+  },
+  "require-dev": {
+    "kwn/php-rdkafka-stubs": "^2.0"
   }
 }


### PR DESCRIPTION
You recently updated your master to v0.3 by replacing rdkafka version.
That's nice, but you forgot about proper [shutdown](https://github.com/arnaud-lb/php-rdkafka#proper-shutdown)

I decided to fix this with PR. 

You have similar changes in your `stable` branch, but i added flus timeout as option. It makes configuration more flexible.