### PR TITLE
fix(headers): remove headers from message json decode

### DIFF
--- a/Messenger/KafkaMessageJsonDecoder.php
+++ b/Messenger/KafkaMessageJsonDecoder.php
@@ -14,8 +14,7 @@ class KafkaMessageJsonDecoder implements KafkaMessageDecoderInterface
         $decodedMessage = json_decode($message->payload, true);
 
         return [
-            'body' => $decodedMessage['body'],
-            'headers' => $decodedMessage['headers']
+            'body' => $decodedMessage['body']
         ];
     }
 


### PR DESCRIPTION
There is an error with this $decodeMessage['header'] because payload have not header.