### PR TITLE
Fix: Move Headers from payload to headers section

### DIFF
--- a/Messenger/KafkaMessageJsonDecoder.php
+++ b/Messenger/KafkaMessageJsonDecoder.php
@@ -11,11 +11,9 @@ class KafkaMessageJsonDecoder implements KafkaMessageDecoderInterface
      */
     public function decode(Message $message): array
     {
-        $decodedMessage = json_decode($message->payload, true);
-
         return [
-            'body' => $decodedMessage['body'],
-            'headers' => $decodedMessage['headers']
+            'body' => $message->payload,
+            'headers' => $message->headers
         ];
     }
 

--- a/Messenger/KafkaTransport.php
+++ b/Messenger/KafkaTransport.php
@@ -157,7 +157,7 @@ class KafkaTransport implements TransportInterface
 
         $payload = $this->serializer->encode($envelope);
 
-        $topic->produce(RD_KAFKA_PARTITION_UA, 0, json_encode($payload));
+        $topic->producev(RD_KAFKA_PARTITION_UA, 0, $payload['body'], null, $payload['headers']);
 
         $producer->flush($this->flushTimeout);
 


### PR DESCRIPTION
The root problem with the serialization from messages that were sent from different programming language comes from sending the headers in the payload.

Decoders are fixing a problem that is only there because the headers are being sent in the payload and not as kafka message headers.

