### PR TITLE
Do not fail on "Local: Broker transport failure" but keep consuming

### DIFF
--- a/Messenger/KafkaTransport.php
+++ b/Messenger/KafkaTransport.php
@@ -94,6 +94,9 @@ class KafkaTransport implements TransportInterface
             case RD_KAFKA_RESP_ERR__TIMED_OUT:
                 $this->logger->debug('Kafka: Consumer timeout.');
                 break;
+            case RD_KAFKA_RESP_ERR__TRANSPORT:
+                $this->logger->debug('Kafka: Broker transport failure.');
+                break;
             default:
                 throw new \Exception($message->errstr(), $message->err);
                 break;


### PR DESCRIPTION
When `Local: Broker transport failure` occures, it not results in a fatal error.

Before we used the Enqueue integration of Kafka and also added there the ignore error.
https://github.com/php-enqueue/rdkafka/blob/master/RdKafkaConsumer.php
This resulted in a stable good working consumer for our Enterprise Kafka environment.

@KonstantinCodes 