### PR TITLE
Require nyholm/psr7 to have a default psr HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "symfony/messenger": "^4.4||^5.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
-    "psr/http-message": "^1.0"
+    "psr/http-message": "^1.0",
+    "nyholm/psr7": "^1.3"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
With the adding of psr HTTP dependencies used for KafkaRestProxy*, we have the following error in our project : 
> Attempted to load class "Psr17Factory" from namespace "Nyholm\Psr7\Factory".

Would it be possible to add  nyholm/psr7 to composer ?

