### PR TITLE
Adds support for failure message during serialization and handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ framework:
                 options:
                     commitAsync: true
                     receiveTimeout: 10000
+                    ackFailedMessages: true
                     topic:
                         name: "events"
                     kafka_conf:
@@ -111,3 +112,14 @@ final class MySerializer extends Serializer
     }
 }
 ```
+
+## Failing messages
+By default this bundle supports the `MessageDecodingFailedException` (when failing deserialization),
+a message will be acknowledged (because there is no reject within Kafka).
+
+When an exception is thrown within a MessageHandlerInterface, a `WorkerMessageFailedEvent` will be
+ fired. The original message will be acknowledged and the retry process is started (creating a retry
+  message or move to failed transport).
+
+If you want to disable the acknowledgement of a failing message, you can configure `ackFailedMessages
+: false` within options.

--- a/src/Messenger/KafkaTransportFactory.php
+++ b/src/Messenger/KafkaTransportFactory.php
@@ -70,7 +70,8 @@ class KafkaTransportFactory implements TransportFactoryInterface
             $options['topic']['name'],
             $options['flushTimeout'] ?? 10000,
             $options['receiveTimeout'] ?? 10000,
-            $options['commitAsync'] ?? false
+            $options['commitAsync'] ?? false,
+            $options['ackFailedMessages'] ?? true
         );
     }
 

--- a/tests/Unit/Messenger/KafkaTransportTest.php
+++ b/tests/Unit/Messenger/KafkaTransportTest.php
@@ -65,7 +65,8 @@ class KafkaTransportTest extends TestCase
             'test',
             10000,
             10000,
-            false
+            false,
+            true
         );
 
         static::assertInstanceOf(TransportInterface::class, $transport);
@@ -104,6 +105,10 @@ class KafkaTransportTest extends TestCase
             ])
             ->willReturn(new Envelope(new TestMessage()));
 
+        $this->mockRdKafkaConsumer
+            ->method('commitAsync')
+            ->with($testMessage);
+
         $transport = new KafkaTransport(
             $this->mockLogger,
             $this->mockSerializer,
@@ -112,7 +117,8 @@ class KafkaTransportTest extends TestCase
             'test',
             10000,
             10000,
-            false
+            false,
+            true
         );
 
         $receivedMessages = $transport->get();


### PR DESCRIPTION
This solves: https://github.com/KonstantinCodes/messenger-kafka/issues/22

When a message is received and there is an MessageDecodingFailedException thrown during serialization or an exception during handling a WorkerMessageFailedEvent will be dispatched.

@KonstantinCodes 