### PR TITLE
Fix headers in KafkaReceiver.php on line 64.

### DIFF
--- a/src/Messenger/KafkaReceiver.php
+++ b/src/Messenger/KafkaReceiver.php
@@ -61,7 +61,7 @@ class KafkaReceiver implements ReceiverInterface
 
                 $envelope = $this->serializer->decode([
                     'body' => $message->payload,
-                    'headers' => $message->headers,
+                    'headers' => $message->headers ?? [],
                     'key' => $message->key,
                     'offset' => $message->offset,
                     'timestamp' => $message->timestamp,


### PR DESCRIPTION
This issue can be reproduced if you use your package on one side and srooze enqueue on other side.

It fixes, because you use declare(strict_types=1):
[ErrorException]
Notice: Undefined property: RdKafka\Message::$headers

it fixes issue: https://github.com/KonstantinCodes/messenger-kafka/issues/37