### PR TITLE
Allow all versions of psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
-    "psr/log": "^1.1"
+    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
Hello,

Thank you for this package. We have run into an issue while trying to use psr/log version 2.0, into one of our projects.

This package explicitly locks you in the version 1, in the composer.json file.

The later versions of psr/log (2.0.0 and 3.0.0) add typehints and make the parameters more strict. But monolog can work with all the interfaces from any version 1.1, 2.0 or 3.0. 

For example this is the implementation of monolog's function info from the LoggerInterface:

```
    /**
     * Adds a log record at the INFO level.
     *
     * This method allows for compatibility with common interfaces.
     *
     * @param string|Stringable $message The log message
     * @param mixed[]           $context The log context
     */
    public function info($message, array $context = []): void
    {
        $this->addRecord(static::INFO, (string) $message, $context);
    }
```

This method implements the interface of the psr/log version 1.1, 2.0 and 3.0 and the reason why is [this](https://wiki.php.net/rfc/parameter-no-type-variance) rfc.

Logger interface version 1.1 from [here](https://github.com/php-fig/log/blob/1.1.4/Psr/Log/LoggerInterface.php)
```
    public function info($message, array $context = array());
```

Logger interface version 2.0 from [here](https://github.com/php-fig/log/blob/1.1.4/Psr/Log/LoggerInterface.php)
```
    public function info(string|\Stringable $message, array $context = []);
```

Both interfaces aboe are implemented from monolog's logger method, so there is no need to lock to version 1.1.
TL;DR;

Parameter widening allows this function to implement the interface from all the versions.

Monolog has the same version requirements as I am doing here in this MR. Please consider allowing more psr/log versions to the user of your package.

Thank you