### PR TITLE
[Messenger] Symfony 6.0 Support and PHP minimal version 7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,17 @@ orbs:
   wait-for: cobli/wait-for@0.0.2
 jobs:
   build:
+    strategy:
+      matrix:
+        php:
+          - "7.4.26"
+          - "8.0.13"
+
     environment:
       CC_TEST_REPORTER_ID: ac6b0ffb95381a6e67239f27805263c12cdb85bc1b8f3bc295173a8cb12ae2b1
     working_directory: ~/messenger-kafka
     docker:
-      - image: circleci/php:7.4.4
+      - image: circleci/php:"${{ matrix.php }}"
       - image: lensesio/fast-data-dev
         environment:
           SAMPLEDATA: 0

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,8 +8,12 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php:
+          - "7.4"
+          - "8.0"
 
     services:
       kafka:
@@ -39,7 +43,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: "${{ matrix.php }}"
           coverage: xdebug
           tools: pecl, phpunit
           extensions: rdkafka

--- a/composer.json
+++ b/composer.json
@@ -5,26 +5,26 @@
   "keywords": ["kafka", "symfony", "messenger", "transport", "queue", "bundle"],
   "license": "MIT",
   "require": {
-    "php": "^7.1.3|8.*",
+    "php": "^7.4|8.*",
     "ext-json": "*",
-    "symfony/config": "^3.0||^4.0||^5.0",
-    "symfony/dependency-injection": "^3.4.26||^4.1.12|^5.0",
-    "symfony/http-kernel": "^3.0||^4.0||^5.0",
-    "symfony/messenger": "^4.4||^5.0",
+    "symfony/config": "^3.0||^4.0||^5.0||^6.0",
+    "symfony/dependency-injection": "^3.4.26||^4.1.12|^5.0||^6.0",
+    "symfony/http-kernel": "^3.0||^4.0||^5.0||^6.0",
+    "symfony/messenger": "^4.4||^5.0||^6.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
     "psr/http-message": "^1.0",
-    "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+    "psr/log": "^1.0.1||^2.0 ||^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.16",
-    "kwn/php-rdkafka-stubs": "^2.0",
-    "symfony/phpunit-bridge": "^5.0",
-    "symfony/framework-bundle": "^5.0",
-    "symfony/serializer": "^5.0",
-    "symfony/property-access": "^5.0",
-    "phpstan/phpstan": "^0.12.52",
-    "nyholm/psr7": "^1.3"
+    "kwn/php-rdkafka-stubs": "^2.1",
+    "symfony/phpunit-bridge": "^5.0||^6.0",
+    "symfony/framework-bundle": "^5.0||^6.0",
+    "symfony/serializer": "^5.0||^6.0",
+    "symfony/property-access": "^5.0||^6.0",
+    "phpstan/phpstan": "^0.12.99",
+    "nyholm/psr7": "^1.4"
   },
   "suggest": {
     "ext-rdkafka": "^4.0; Needed to support Kafka connectivity",

--- a/src/Messenger/KafkaReceiver.php
+++ b/src/Messenger/KafkaReceiver.php
@@ -14,23 +14,12 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class KafkaReceiver implements ReceiverInterface
 {
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var SerializerInterface */
-    private $serializer;
-
-    /** @var RdKafkaFactory */
-    private $rdKafkaFactory;
-
-    /** @var KafkaReceiverProperties */
-    private $properties;
-
-    /** @var KafkaConsumer */
-    private $consumer;
-
-    /** @var bool */
-    private $subscribed;
+    private LoggerInterface $logger;
+    private SerializerInterface $serializer;
+    private RdKafkaFactory $rdKafkaFactory;
+    private KafkaReceiverProperties $properties;
+    private KafkaConsumer $consumer;
+    private bool $subscribed;
 
     public function __construct(
         LoggerInterface $logger,

--- a/src/Serializer/AbstractKafkaRestProxyBinarySerializer.php
+++ b/src/Serializer/AbstractKafkaRestProxyBinarySerializer.php
@@ -11,7 +11,7 @@ abstract class AbstractKafkaRestProxyBinarySerializer implements SerializerInter
 {
     public function decode(array $encodedEnvelope): Envelope
     {
-        // TODO: Implement decode() method.
+        throw new \LogicException('Method not implemented yet');
     }
 
     public function encode(Envelope $envelope): array


### PR DESCRIPTION
[Messenger] Symfony 6.0 Support and PHP minimal version 7.4, because php.net drops support of 7.3 on 6 December 2021, Also added support for ext-rdkafka >= 5.0