### PR TITLE
Empty sasl.username disables sasl.authentication

### DIFF
--- a/src/Messenger/KafkaTransportFactory.php
+++ b/src/Messenger/KafkaTransportFactory.php
@@ -64,7 +64,17 @@ class KafkaTransportFactory implements TransportFactoryInterface
         $brokers = $this->stripProtocol($dsn);
         $conf->set('metadata.broker.list', implode(',', $brokers));
 
-        foreach (array_merge($options['topic_conf'] ?? [], $options['kafka_conf'] ?? []) as $option => $value) {
+        $configOptions = array_merge($options['topic_conf'] ?? [], $options['kafka_conf'] ?? []);
+
+        // Empty sasl.username should unset other sasl authentication fields
+        if (empty($configOptions['sasl.username'])) {
+            unset($configOptions['security.protocol']);
+            unset($configOptions['sasl.mechanisms']);
+            unset($configOptions['sasl.username']);
+            unset($configOptions['sasl.password']);
+        }
+
+        foreach ($configOptions as $option => $value) {
             $conf->set($option, $value);
         }
 


### PR DESCRIPTION
I found it very convenient to disable sasl authentication on dev machine by simple setting sasl.username into empty string. 

So I have messenger config like so:
```yaml
framework:
    messenger:
        reset_on_message: true
        transports:
          dsp:
              dsn: 'kafka://%env(DSP_KAFKA_HOSTS)%'
              options:
                  topic:
                      name: "%env(DSP_KAFKA_TOPIC_NAME)%"
                  kafka_conf:
                      security.protocol: 'sasl_plaintext'
                      sasl.mechanisms: 'SCRAM-SHA-256'
                      sasl.username: '%env(DSP_KAFKA_USERNAME)%'
                      sasl.password: '%env(DSP_KAFKA_PASSWORD)%'
```

On production server i have non-empty `DSP_KAFKA_USERNAME` but on local dev machine `DSP_KAFKA_USERNAME=''` and there is only one `messenger.yaml`