### PR TITLE
Php84 deprecation

### DIFF
--- a/src/Messenger/KafkaTransportFactory.php
+++ b/src/Messenger/KafkaTransportFactory.php
@@ -102,7 +102,7 @@ class KafkaTransportFactory implements TransportFactoryInterface
 
     private function createRebalanceCb(LoggerInterface $logger): \Closure
     {
-        return function (KafkaConsumer $kafka, $err, array $topicPartitions = null) use ($logger) {
+        return function (KafkaConsumer $kafka, $err, ?array $topicPartitions = null) use ($logger) {
             /** @var TopicPartition[] $topicPartitions */
             $topicPartitions = $topicPartitions ?? [];
 

--- a/src/Messenger/RestProxyTransportFactory.php
+++ b/src/Messenger/RestProxyTransportFactory.php
@@ -117,7 +117,7 @@ class RestProxyTransportFactory implements TransportFactoryInterface
         }
     }
 
-    private function createMissingServiceException(string $className, string $message = null)
+    private function createMissingServiceException(string $className, ?string $message = null)
     {
         return new \InvalidArgumentException(sprintf(
             '%sPlease install a library that provides "%s" and ensure the service is registered.',


### PR DESCRIPTION
Caught some deprecations in PHP 8.4:
```
PHP Deprecated:  {closure:Koco\Kafka\Messenger\KafkaTransportFactory::createRebalanceCb():105}(): Implicitly marking parameter $topicPartitions as nullable is deprecated, the explicit nullable type must be used instead in /service/vendor/koco/messenger-kafka/src/Messenger/KafkaTransportFactory.php on line 105
```
```
PHP Deprecated:  Koco\Kafka\Messenger\RestProxyTransportFactory::createMissingServiceException(): Implicitly marking parameter $message as nullable is deprecated, the explicit nullable type must be used instead in /service/vendor/koco/messenger-kafka/src/Messenger/RestProxyTransportFactory.php on line 120
```

A minor fix
