### PR TITLE
Fix PHP 8.4+ implicit nullable type deprecations

### DIFF
--- a/src/Messenger/KafkaTransportFactory.php
+++ b/src/Messenger/KafkaTransportFactory.php
@@ -102,7 +102,7 @@ class KafkaTransportFactory implements TransportFactoryInterface
 
     private function createRebalanceCb(LoggerInterface $logger): \Closure
     {
-        return function (KafkaConsumer $kafka, $err, array $topicPartitions = null) use ($logger) {
+        return function (KafkaConsumer $kafka, $err, ?array $topicPartitions = null) use ($logger) {
             /** @var TopicPartition[] $topicPartitions */
             $topicPartitions = $topicPartitions ?? [];
 

--- a/src/Messenger/RestProxyTransportFactory.php
+++ b/src/Messenger/RestProxyTransportFactory.php
@@ -117,7 +117,7 @@ class RestProxyTransportFactory implements TransportFactoryInterface
         }
     }
 
-    private function createMissingServiceException(string $className, string $message = null)
+    private function createMissingServiceException(string $className, ?string $message = null)
     {
         return new \InvalidArgumentException(sprintf(
             '%sPlease install a library that provides "%s" and ensure the service is registered.',


### PR DESCRIPTION
This little fix eliminates PHP 8.4+ implicitly nullable parameter deprecation
https://www.php.net/manual/en/migration84.deprecated.php
